### PR TITLE
Fix GitHub Actions release deletion to prevent failures

### DIFF
--- a/.github/workflows/build-wpf.yml
+++ b/.github/workflows/build-wpf.yml
@@ -87,7 +87,13 @@ jobs:
         copy "./artifacts/RemainingTimeMeter-self-contained-win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x86.exe"
         
     - name: Delete previous latest release
-      run: gh release delete latest --yes || echo "No previous latest release found"
+      run: |
+        if gh release view latest >/dev/null 2>&1; then
+          echo "Deleting existing latest release..."
+          gh release delete latest --yes --cleanup-tag
+        else
+          echo "No previous latest release found"
+        fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
## Summary
- Fix the GitHub Actions workflow to prevent failures when deleting the 'latest' release
- Improve error handling and logging in the release deletion step

## Changes Made
- Added proper existence check before attempting to delete the 'latest' release
- Used `--cleanup-tag` flag to properly clean up associated Git tags
- Enhanced error messaging for better debugging

## Problem Solved
The workflow was failing when trying to delete a 'latest' release that didn't exist, causing the entire build pipeline to fail. This fix ensures the workflow continues successfully regardless of whether a previous 'latest' release exists.

## Test plan
- [x] Verify the workflow syntax is correct
- [ ] Test the workflow runs successfully on push to master
- [ ] Confirm proper handling when no previous 'latest' release exists
- [ ] Verify successful creation of new 'latest' release after deletion

🤖 Generated with [Claude Code](https://claude.ai/code)