### PR TITLE
Fix project file reference to deleted icon file

### DIFF
--- a/wpf/MainWindow.xaml
+++ b/wpf/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="残り時間メーター" Height="350" Width="400"
         WindowStartupLocation="CenterScreen"
-        Icon="tv_timekeeper.ico">
+        Icon="tv_timekeeper_trimmed.ico">
     <Grid>
         <StackPanel Margin="20" VerticalAlignment="Center">
             <TextBlock Text="Remaining Time Meter" FontSize="24" FontWeight="Bold" 

--- a/wpf/RemainingTimeMeter.csproj
+++ b/wpf/RemainingTimeMeter.csproj
@@ -34,7 +34,6 @@
 
     <ItemGroup>
         <Resource Include="tv_timekeeper_trimmed.ico" />
-        <None Remove="tv_timekeeper.ico" />
     </ItemGroup>
 
     <ItemGroup>

--- a/wpf/TimerWindow.xaml
+++ b/wpf/TimerWindow.xaml
@@ -8,7 +8,7 @@
         Topmost="True"
         ShowInTaskbar="False"
         ResizeMode="NoResize"
-        Icon="tv_timekeeper.ico"
+        Icon="tv_timekeeper_trimmed.ico"
         MouseEnter="Window_MouseEnter"
         MouseLeave="Window_MouseLeave">
 


### PR DESCRIPTION
## Summary
- Remove reference to deleted tv_timekeeper.ico file from project configuration
- Prevents build warnings and ensures clean project setup

## Changes Made
- Removed `<None Remove="tv_timekeeper.ico" />` line from RemainingTimeMeter.csproj
- The file was already deleted in previous commits but the reference remained

## Test Results
✅ Project builds cleanly without warnings
✅ Application launches successfully

🤖 Generated with [Claude Code](https://claude.ai/code)