### PR TITLE
Fix textbox auto-select behavior for mouse clicks

### DIFF
--- a/wpf/MainWindow.xaml
+++ b/wpf/MainWindow.xaml
@@ -11,9 +11,9 @@
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
                 <TextBlock Text="時間設定: " VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBox x:Name="MinutesTextBox" Width="50" Text="5" HorizontalContentAlignment="Center" GotFocus="TextBox_GotFocus"/>
+                <TextBox x:Name="MinutesTextBox" Width="50" Text="5" HorizontalContentAlignment="Center" GotFocus="TextBox_GotFocus" PreviewMouseLeftButtonDown="TextBox_PreviewMouseLeftButtonDown"/>
                 <TextBlock Text="分" VerticalAlignment="Center" Margin="5,0,5,0"/>
-                <TextBox x:Name="SecondsTextBox" Width="50" Text="00" HorizontalContentAlignment="Center" GotFocus="TextBox_GotFocus"/>
+                <TextBox x:Name="SecondsTextBox" Width="50" Text="00" HorizontalContentAlignment="Center" GotFocus="TextBox_GotFocus" PreviewMouseLeftButtonDown="TextBox_PreviewMouseLeftButtonDown"/>
                 <TextBlock Text="秒" VerticalAlignment="Center" Margin="5,0,0,0"/>
             </StackPanel>
 

--- a/wpf/MainWindow.xaml.cs
+++ b/wpf/MainWindow.xaml.cs
@@ -240,5 +240,31 @@ namespace RemainingTimeMeter
                 Logger.Error("TextBox_GotFocus failed", ex);
             }
         }
+
+        /// <summary>
+        /// Handles the PreviewMouseLeftButtonDown event for textboxes to ensure proper focus and selection behavior.
+        /// </summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void TextBox_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            Logger.Debug("TextBox_PreviewMouseLeftButtonDown started");
+            try
+            {
+                if (sender is System.Windows.Controls.TextBox textBox)
+                {
+                    if (!textBox.IsKeyboardFocusWithin)
+                    {
+                        textBox.Focus();
+                        e.Handled = true;
+                        Logger.Debug($"Focused textbox: {textBox.Name}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("TextBox_PreviewMouseLeftButtonDown failed", ex);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
• Fix textbox auto-select functionality to work consistently with both Tab navigation and mouse clicks
• Add PreviewMouseLeftButtonDown event handlers to properly handle focus before text selection

## Test plan
- [ ] Test textbox auto-select with Tab key navigation (should continue working)
- [ ] Test textbox auto-select with mouse clicks (should now work properly)
- [ ] Verify both MinutesTextBox and SecondsTextBox behave consistently

🤖 Generated with [Claude Code](https://claude.ai/code)