### PR TITLE
Migrate GitHub Actions workflows from Windows to Ubuntu runners

### DIFF
--- a/.github/workflows/build-wpf.yml
+++ b/.github/workflows/build-wpf.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     
     steps:
     - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
 
   release-latest:
     needs: build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     
     steps:
@@ -80,11 +80,11 @@ jobs:
         
     - name: Create release directory and copy files
       run: |
-        mkdir release
-        copy "./artifacts/RemainingTimeMeter-framework-dependent-win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x64.exe"
-        copy "./artifacts/RemainingTimeMeter-framework-dependent-win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x86.exe"
-        copy "./artifacts/RemainingTimeMeter-self-contained-win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x64.exe"
-        copy "./artifacts/RemainingTimeMeter-self-contained-win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x86.exe"
+        mkdir -p release
+        cp "./artifacts/RemainingTimeMeter-framework-dependent-win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x64.exe"
+        cp "./artifacts/RemainingTimeMeter-framework-dependent-win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x86.exe"
+        cp "./artifacts/RemainingTimeMeter-self-contained-win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x64.exe"
+        cp "./artifacts/RemainingTimeMeter-self-contained-win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x86.exe"
         
     - name: Delete previous latest release
       run: |
@@ -158,7 +158,7 @@ jobs:
 
   release-tagged:
     needs: build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     
     steps:
@@ -186,10 +186,10 @@ jobs:
     # Rename files for clarity
     - name: Rename release files
       run: |
-        move "./release/framework-dependent/win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x64.exe"
-        move "./release/framework-dependent/win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x86.exe"
-        move "./release/self-contained/win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x64.exe"
-        move "./release/self-contained/win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x86.exe"
+        mv "./release/framework-dependent/win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x64.exe"
+        mv "./release/framework-dependent/win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-framework-dependent-win-x86.exe"
+        mv "./release/self-contained/win-x64/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x64.exe"
+        mv "./release/self-contained/win-x86/RemainingTimeMeter.exe" "./release/RemainingTimeMeter-self-contained-win-x86.exe"
       
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: wpf


### PR DESCRIPTION
## Summary
• Migrate all GitHub Actions workflows from Windows to Ubuntu runners for better reliability and performance
• Replace Windows-specific commands (copy, mkdir, move) with Unix equivalents (cp, mkdir -p, mv)
• Maintain cross-compilation support for Windows binaries using .NET SDK

## Test plan
- [ ] Verify CI workflow runs successfully on Ubuntu
- [ ] Verify build workflow produces Windows binaries correctly
- [ ] Verify release-latest workflow completes without errors
- [ ] Test that published Windows executables work properly

🤖 Generated with [Claude Code](https://claude.ai/code)