### PR TITLE
Enhance make format to remove trailing whitespace

### DIFF
--- a/wpf/Makefile
+++ b/wpf/Makefile
@@ -76,6 +76,7 @@ test:
 .PHONY: format
 format:
 	dotnet format $(CSPROJ_FILE)
+	dotnet format whitespace $(CSPROJ_FILE)
 
 # Show help
 .PHONY: help


### PR DESCRIPTION
## Summary
- Add `dotnet format whitespace` command to `make format` target to ensure all trailing whitespace is removed during formatting

## Test plan
- [x] Verify `make format` now includes whitespace removal
- [x] Test that the command runs successfully
- [x] Confirm trailing whitespace is properly removed

🤖 Generated with [Claude Code](https://claude.ai/code)