### PR TITLE
Standardize UI language consistency between Japanese and English

### DIFF
--- a/wpf/MainWindow.xaml
+++ b/wpf/MainWindow.xaml
@@ -6,7 +6,7 @@
         Icon="tv_timekeeper_trimmed.ico">
     <Grid>
         <StackPanel Margin="20" VerticalAlignment="Center">
-            <TextBlock Text="Remaining Time Meter" FontSize="24" FontWeight="Bold" 
+            <TextBlock Text="残り時間メーター" FontSize="24" FontWeight="Bold" 
                        HorizontalAlignment="Center" Margin="0,0,0,20"/>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">

--- a/wpf/MainWindow.xaml.cs
+++ b/wpf/MainWindow.xaml.cs
@@ -76,7 +76,7 @@ namespace RemainingTimeMeter
 
                     this.DisplayComboBox.Items.Add(item);
 
-                    // 主画面を既定値として選択
+                    // Select primary display as default
                     if (display.IsPrimary)
                     {
                         this.DisplayComboBox.SelectedItem = item;
@@ -106,7 +106,7 @@ namespace RemainingTimeMeter
             {
                 Logger.Debug($"Processing screen: {screen.DeviceName}, Primary: {screen.Primary}, Bounds: {screen.Bounds}");
 
-                // DPI情報を取得 - ウィンドウが完全に初期化されていない場合はデフォルト値を使用
+                // Get DPI information - use default values if window is not fully initialized
                 double scaleX = 1.0;
                 double scaleY = 1.0;
 
@@ -161,7 +161,7 @@ namespace RemainingTimeMeter
             {
                 Logger.Debug($"Input values - Minutes: '{this.MinutesTextBox.Text}', Seconds: '{this.SecondsTextBox.Text}'");
 
-                // 入力値の検証
+                // Validate input values
                 if (!int.TryParse(this.MinutesTextBox.Text, out int minutes) || minutes < 0)
                 {
                     Logger.Debug("Invalid minutes input");
@@ -176,7 +176,7 @@ namespace RemainingTimeMeter
                     return;
                 }
 
-                // 総時間を秒で計算
+                // Calculate total time in seconds
                 int totalSeconds = (minutes * 60) + seconds;
                 Logger.Debug($"Calculated total seconds: {totalSeconds}");
                 if (totalSeconds <= 0)
@@ -186,16 +186,16 @@ namespace RemainingTimeMeter
                     return;
                 }
 
-                // 配置位置を取得
+                // Get position setting
                 string position = ((ComboBoxItem)this.PositionComboBox.SelectedItem).Content.ToString() ?? "右端";
                 Logger.Debug($"Selected position: {position}");
 
-                // 選択されたディスプレーを取得
+                // Get selected display
                 var selectedDisplayItem = (ComboBoxItem)this.DisplayComboBox.SelectedItem;
                 var selectedDisplay = (DisplayInfo)selectedDisplayItem.Tag;
                 Logger.Debug($"Selected display: {selectedDisplay.Width}x{selectedDisplay.Height} at ({selectedDisplay.Left}, {selectedDisplay.Top}), Primary: {selectedDisplay.IsPrimary}");
 
-                // タイマーウィンドウを作成して表示
+                // Create and show timer window
                 Logger.Debug("Creating TimerWindow");
                 var timerWindow = new TimerWindow(totalSeconds, position, selectedDisplay);
                 timerWindow.MainWindowRequested += () =>
@@ -206,7 +206,7 @@ namespace RemainingTimeMeter
                 Logger.Debug("Showing TimerWindow");
                 timerWindow.Show();
 
-                // メインウィンドウを非表示
+                // Hide main window
                 Logger.Debug("Hiding MainWindow");
                 this.Hide();
 

--- a/wpf/TimerWindow.xaml.cs
+++ b/wpf/TimerWindow.xaml.cs
@@ -119,16 +119,16 @@ namespace RemainingTimeMeter
         /// </summary>
         private void SetupWindowPosition()
         {
-            // DPIスケーリングを考慮した座標計算
+            // Calculate coordinates considering DPI scaling
             var dpiScale = System.Windows.Media.VisualTreeHelper.GetDpi(this);
 
-            // 物理ピクセルでのスクリーン情報
+            // Screen information in physical pixels
             var screenWidth = this.targetDisplay.Width;
             var screenHeight = this.targetDisplay.Height;
             var screenLeft = this.targetDisplay.Left;
             var screenTop = this.targetDisplay.Top;
 
-            // WPFのロジカルピクセルに変換
+            // Convert to WPF logical pixels
             var logicalScreenWidth = screenWidth / dpiScale.DpiScaleX;
             var logicalScreenHeight = screenHeight / dpiScale.DpiScaleY;
             var logicalScreenLeft = screenLeft / dpiScale.DpiScaleX;
@@ -206,17 +206,17 @@ namespace RemainingTimeMeter
 
             if (this.position == TimerPosition.Top || this.position == TimerPosition.Bottom)
             {
-                // 横方向の場合は左から右に向かって進捗を表示
+                // For horizontal orientation, show progress from left to right
                 this.ProgressBar.Width = this.Width * progress;
-                this.ProgressBar.Height = this.Height; // 高さは全体に設定
+                this.ProgressBar.Height = this.Height; // Set height to full size
                 this.ProgressBar.HorizontalAlignment = System.Windows.HorizontalAlignment.Left;
                 this.ProgressBar.VerticalAlignment = System.Windows.VerticalAlignment.Stretch;
             }
             else
             {
-                // 縦方向の場合は下から上に向かって進捗を表示
+                // For vertical orientation, show progress from bottom to top
                 this.ProgressBar.Height = this.Height * progress;
-                this.ProgressBar.Width = this.Width; // 幅は全体に設定
+                this.ProgressBar.Width = this.Width; // Set width to full size
                 this.ProgressBar.VerticalAlignment = System.Windows.VerticalAlignment.Bottom;
                 this.ProgressBar.HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch;
             }
@@ -227,7 +227,7 @@ namespace RemainingTimeMeter
         /// </summary>
         private void UpdateBarColor()
         {
-            // 一時停止中は darkslateblue に設定
+            // Set to darkslateblue when paused
             if (this.isPaused)
             {
                 this.ProgressBar.Fill = new SolidColorBrush(Colors.DarkSlateBlue);
@@ -242,7 +242,7 @@ namespace RemainingTimeMeter
             {
                 this.ProgressBar.Fill = new SolidColorBrush(Colors.Red);
 
-                // 点滅効果
+                // Blinking effect
                 var animation = new DoubleAnimation(Constants.BlinkMinOpacity, Constants.BlinkMaxOpacity, TimeSpan.FromMilliseconds(Constants.BlinkAnimationDuration))
                 {
                     AutoReverse = true,
@@ -269,19 +269,19 @@ namespace RemainingTimeMeter
         /// </summary>
         private void ShowTimeUpNotification()
         {
-            // 経過時間を計算
+            // Calculate elapsed time
             int minutes = this.totalSeconds / 60;
             int seconds = this.totalSeconds % 60;
             string message = $"時間です！{minutes}分{seconds}秒経過しました！";
 
             try
             {
-                // Windows 10/11のシステム通知を使用
+                // Use Windows 10/11 system notifications
                 this.ShowWindowsNotification("タイマー", message);
             }
             catch
             {
-                // フォールバックとしてメッセージボックスを表示
+                // Show message box as fallback
                 System.Windows.MessageBox.Show(message, "タイマー", MessageBoxButton.OK, MessageBoxImage.Information);
             }
 
@@ -296,7 +296,7 @@ namespace RemainingTimeMeter
         /// <param name="message">Notification message.</param>
         private void ShowWindowsNotification(string title, string message)
         {
-            // NotifyIconを使用してシステム通知を表示
+            // Show system notification using NotifyIcon
             var notifyIcon = new System.Windows.Forms.NotifyIcon();
             try
             {
@@ -304,7 +304,7 @@ namespace RemainingTimeMeter
                 notifyIcon.Visible = true;
                 notifyIcon.ShowBalloonTip(Constants.NotificationDuration, title, message, System.Windows.Forms.ToolTipIcon.Info);
 
-                // 通知表示後に自動的にアイコンを非表示にする
+                // Automatically hide icon after showing notification
                 var timer = new DispatcherTimer
                 {
                     Interval = TimeSpan.FromMilliseconds(Constants.NotificationCleanupDelay),
@@ -331,7 +331,7 @@ namespace RemainingTimeMeter
         /// <param name="e">The event arguments.</param>
         private void Window_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            // DPIスケーリングを考慮した座標計算
+            // Calculate coordinates considering DPI scaling
             var dpiScale = System.Windows.Media.VisualTreeHelper.GetDpi(this);
 
             var screenWidth = this.targetDisplay.Width;
@@ -339,7 +339,7 @@ namespace RemainingTimeMeter
             var screenLeft = this.targetDisplay.Left;
             var screenTop = this.targetDisplay.Top;
 
-            // WPFのロジカルピクセルに変換
+            // Convert to WPF logical pixels
             var logicalScreenWidth = screenWidth / dpiScale.DpiScaleX;
             var logicalScreenHeight = screenHeight / dpiScale.DpiScaleY;
             var logicalScreenLeft = screenLeft / dpiScale.DpiScaleX;
@@ -383,7 +383,7 @@ namespace RemainingTimeMeter
         /// <param name="e">The event arguments.</param>
         private void Window_MouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            // ホバー終了時に元のサイズに戻す
+            // Restore original size when hover ends
             this.SetupWindowPosition();
             this.ControlPanel.Visibility = Visibility.Collapsed;
             this.TimerBorder.Visibility = Visibility.Visible;
@@ -401,7 +401,7 @@ namespace RemainingTimeMeter
             {
                 this.isPaused = !this.isPaused;
                 this.PauseResumeButton.Content = this.isPaused ? "再開" : "一時停止";
-                this.UpdateBarColor(); // 一時停止状態の変更時に色を更新
+                this.UpdateBarColor(); // Update color when pause state changes
                 Logger.Info($"PauseResumeButton_Click completed - new state: isPaused={this.isPaused}");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Standardize MainWindow header to use Japanese consistently with the rest of the UI
- Convert mixed Japanese/English code comments to English for developer consistency
- Maintain clear separation: Japanese for user interface, English for code documentation

## Test plan
- [x] Verify MainWindow displays "残り時間メーター" header correctly
- [x] Ensure all user-facing messages remain in Japanese
- [x] Confirm code comments are now consistently in English
- [x] Check that application functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)