### PR TITLE
Fix self-contained build issue by adding IncludeNativeLibrariesForSelfExtract

### DIFF
--- a/wpf/Makefile
+++ b/wpf/Makefile
@@ -41,7 +41,8 @@ publish:
 		--self-contained true \
 		--output $(PUBLISH_DIR) \
 		--property:PublishSingleFile=true \
-		--property:PublishTrimmed=false
+		--property:PublishTrimmed=false \
+		--property:IncludeNativeLibrariesForSelfExtract=true
 
 # Publish debug version with logging
 .PHONY: publish-debug

--- a/wpf/RemainingTimeMeter.csproj
+++ b/wpf/RemainingTimeMeter.csproj
@@ -33,6 +33,9 @@
         <InvariantGlobalization>false</InvariantGlobalization>
         <MetadataUpdaterSupport>false</MetadataUpdaterSupport>
         <UseSystemResourceKeys>true</UseSystemResourceKeys>
+        
+        <!-- WPFアプリケーション用のネイティブライブラリ自動展開設定 -->
+        <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
 
         <!-- Windows Formsとの競合を避けるため、トリミングは条件付きで有効化 -->
         <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>


### PR DESCRIPTION
## Problem

Self-contained EXE from GitHub Releases fails to start due to missing WPF native libraries.

## Solution

- Added  to project file and Makefile
- Native libraries (wpfgfx_cor3.dll, PenImc_cor3.dll, etc.) are now embedded and auto-extracted at runtime

## Result
- Self-contained EXE now runs standalone without separate DLL files
- EXE size increased from 147MB to 155MB
- Framework-dependent version unaffected