### PR TITLE
Implement comprehensive internationalization (i18n) support

### DIFF
--- a/wpf/MainWindow.xaml
+++ b/wpf/MainWindow.xaml
@@ -1,38 +1,39 @@
 <Window x:Class="RemainingTimeMeter.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="残り時間メーター" Height="350" Width="400"
+                xmlns:properties="clr-namespace:RemainingTimeMeter.Properties"
+        Title="{Binding Source={x:Static properties:Resources.AppTitle}}" Height="350" Width="400"
         WindowStartupLocation="CenterScreen"
         Icon="tv_timekeeper_trimmed.ico">
     <Grid>
         <StackPanel Margin="20" VerticalAlignment="Center">
-            <TextBlock Text="残り時間メーター" FontSize="24" FontWeight="Bold" 
+            <TextBlock Text="{Binding Source={x:Static properties:Resources.AppTitle}}" FontSize="24" FontWeight="Bold" 
                        HorizontalAlignment="Center" Margin="0,0,0,20"/>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
-                <TextBlock Text="時間設定: " VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding Source={x:Static properties:Resources.TimeSetting}}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBox x:Name="MinutesTextBox" Width="50" Text="5" HorizontalContentAlignment="Center" GotFocus="TextBox_GotFocus" PreviewMouseLeftButtonDown="TextBox_PreviewMouseLeftButtonDown"/>
-                <TextBlock Text="分" VerticalAlignment="Center" Margin="5,0,5,0"/>
+                <TextBlock Text="{Binding Source={x:Static properties:Resources.Minutes}}" VerticalAlignment="Center" Margin="5,0,5,0"/>
                 <TextBox x:Name="SecondsTextBox" Width="50" Text="00" HorizontalContentAlignment="Center" GotFocus="TextBox_GotFocus" PreviewMouseLeftButtonDown="TextBox_PreviewMouseLeftButtonDown"/>
-                <TextBlock Text="秒" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                <TextBlock Text="{Binding Source={x:Static properties:Resources.Seconds}}" VerticalAlignment="Center" Margin="5,0,0,0"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
-                <TextBlock Text="表示ディスプレー: " VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding Source={x:Static properties:Resources.DisplayMonitor}}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <ComboBox x:Name="DisplayComboBox" Width="200" SelectedIndex="0"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
-                <TextBlock Text="配置位置: " VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding Source={x:Static properties:Resources.Position}}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <ComboBox x:Name="PositionComboBox" Width="100" SelectedIndex="0">
-                    <ComboBoxItem Content="右端"/>
-                    <ComboBoxItem Content="左端"/>
-                    <ComboBoxItem Content="上端"/>
-                    <ComboBoxItem Content="下端"/>
+                    <ComboBoxItem Content="{Binding Source={x:Static properties:Resources.PositionRight}}"/>
+                    <ComboBoxItem Content="{Binding Source={x:Static properties:Resources.PositionLeft}}"/>
+                    <ComboBoxItem Content="{Binding Source={x:Static properties:Resources.PositionTop}}"/>
+                    <ComboBoxItem Content="{Binding Source={x:Static properties:Resources.PositionBottom}}"/>
                 </ComboBox>
             </StackPanel>
 
-            <Button x:Name="StartButton" Content="開始" Width="100" Height="40" 
+            <Button x:Name="StartButton" Content="{Binding Source={x:Static properties:Resources.Start}}" Width="100" Height="40" 
                     FontSize="16" Click="StartButton_Click"/>
         </StackPanel>
     </Grid>

--- a/wpf/MainWindow.xaml.cs
+++ b/wpf/MainWindow.xaml.cs
@@ -59,12 +59,12 @@ namespace RemainingTimeMeter
 
                     if (display.IsPrimary)
                     {
-                        displayName = $"ディスプレー {i + 1} (主画面) - {display.Width}x{display.Height}";
+                        displayName = string.Format(Properties.Resources.DisplayFormatPrimary, i + 1, display.Width, display.Height);
                         Logger.Debug($"Primary display found: {displayName}");
                     }
                     else
                     {
-                        displayName = $"ディスプレー {i + 1} - {display.Width}x{display.Height}";
+                        displayName = string.Format(Properties.Resources.DisplayFormat, i + 1, display.Width, display.Height);
                         Logger.Debug($"Secondary display found: {displayName}");
                     }
 
@@ -165,14 +165,14 @@ namespace RemainingTimeMeter
                 if (!int.TryParse(this.MinutesTextBox.Text, out int minutes) || minutes < 0)
                 {
                     Logger.Debug("Invalid minutes input");
-                    System.Windows.MessageBox.Show("分の値が正しくありません。", "エラー", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    System.Windows.MessageBox.Show(Properties.Resources.InvalidMinutesValue, Properties.Resources.Error, MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
                 }
 
                 if (!int.TryParse(this.SecondsTextBox.Text, out int seconds) || seconds < 0 || seconds >= 60)
                 {
                     Logger.Debug("Invalid seconds input");
-                    System.Windows.MessageBox.Show("秒の値が正しくありません（0-59）。", "エラー", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    System.Windows.MessageBox.Show(Properties.Resources.InvalidSecondsValue, Properties.Resources.Error, MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
                 }
 
@@ -182,12 +182,12 @@ namespace RemainingTimeMeter
                 if (totalSeconds <= 0)
                 {
                     Logger.Debug("Total seconds is zero or negative");
-                    System.Windows.MessageBox.Show("時間を正しく設定してください。", "エラー", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    System.Windows.MessageBox.Show(Properties.Resources.PleaseSetTimeCorrectly, Properties.Resources.Error, MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
                 }
 
                 // Get position setting
-                string position = ((ComboBoxItem)this.PositionComboBox.SelectedItem).Content.ToString() ?? "右端";
+                string position = ((ComboBoxItem)this.PositionComboBox.SelectedItem).Content.ToString() ?? Properties.Resources.PositionRight;
                 Logger.Debug($"Selected position: {position}");
 
                 // Get selected display
@@ -215,7 +215,7 @@ namespace RemainingTimeMeter
             catch (Exception ex)
             {
                 Logger.Error("StartButton_Click failed", ex);
-                System.Windows.MessageBox.Show($"エラーが発生しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+                System.Windows.MessageBox.Show(string.Format(Properties.Resources.ErrorOccurred, ex.Message), Properties.Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 

--- a/wpf/Properties/Resources.Designer.cs
+++ b/wpf/Properties/Resources.Designer.cs
@@ -1,0 +1,318 @@
+// <copyright file="Resources.Designer.cs" company="RemainingTimeMeter">
+// Copyright (c) 2025 RemainingTimeMeter. Licensed under the MIT License.
+// </copyright>
+
+namespace RemainingTimeMeter.Properties
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Resources;
+
+    /// <summary>
+    /// A strongly-typed resource class, for looking up localized strings, etc.
+    /// </summary>
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    public class Resources
+    {
+        private static global::System.Resources.ResourceManager resourceMan;
+
+        private static global::System.Globalization.CultureInfo resourceCulture;
+
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        internal Resources()
+        {
+        }
+
+        /// <summary>
+        /// Returns the cached ResourceManager instance used by this class.
+        /// </summary>
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("RemainingTimeMeter.Properties.Resources", typeof(Resources).Assembly);
+                    resourceMan = temp;
+                }
+
+                return resourceMan;
+            }
+        }
+
+        /// <summary>
+        /// Overrides the current thread's CurrentUICulture property for all
+        /// resource lookups using this strongly typed resource class.
+        /// </summary>
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
+                return resourceCulture;
+            }
+
+            set
+            {
+                resourceCulture = value;
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Remaining Time Meter.
+        /// </summary>
+        public static string AppTitle
+        {
+            get
+            {
+                return ResourceManager.GetString("AppTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Display {0} - {1}x{2}.
+        /// </summary>
+        public static string DisplayFormat
+        {
+            get
+            {
+                return ResourceManager.GetString("DisplayFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Display {0} (Primary) - {1}x{2}.
+        /// </summary>
+        public static string DisplayFormatPrimary
+        {
+            get
+            {
+                return ResourceManager.GetString("DisplayFormatPrimary", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Display Monitor: .
+        /// </summary>
+        public static string DisplayMonitor
+        {
+            get
+            {
+                return ResourceManager.GetString("DisplayMonitor", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Error.
+        /// </summary>
+        public static string Error
+        {
+            get
+            {
+                return ResourceManager.GetString("Error", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to An error occurred: {0}.
+        /// </summary>
+        public static string ErrorOccurred
+        {
+            get
+            {
+                return ResourceManager.GetString("ErrorOccurred", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Invalid minutes value.
+        /// </summary>
+        public static string InvalidMinutesValue
+        {
+            get
+            {
+                return ResourceManager.GetString("InvalidMinutesValue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Invalid seconds value (0-59).
+        /// </summary>
+        public static string InvalidSecondsValue
+        {
+            get
+            {
+                return ResourceManager.GetString("InvalidSecondsValue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to minutes.
+        /// </summary>
+        public static string Minutes
+        {
+            get
+            {
+                return ResourceManager.GetString("Minutes", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Pause.
+        /// </summary>
+        public static string Pause
+        {
+            get
+            {
+                return ResourceManager.GetString("Pause", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Please set the time correctly.
+        /// </summary>
+        public static string PleaseSetTimeCorrectly
+        {
+            get
+            {
+                return ResourceManager.GetString("PleaseSetTimeCorrectly", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Position: .
+        /// </summary>
+        public static string Position
+        {
+            get
+            {
+                return ResourceManager.GetString("Position", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Bottom edge.
+        /// </summary>
+        public static string PositionBottom
+        {
+            get
+            {
+                return ResourceManager.GetString("PositionBottom", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Left edge.
+        /// </summary>
+        public static string PositionLeft
+        {
+            get
+            {
+                return ResourceManager.GetString("PositionLeft", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Right edge.
+        /// </summary>
+        public static string PositionRight
+        {
+            get
+            {
+                return ResourceManager.GetString("PositionRight", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Top edge.
+        /// </summary>
+        public static string PositionTop
+        {
+            get
+            {
+                return ResourceManager.GetString("PositionTop", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Resume.
+        /// </summary>
+        public static string Resume
+        {
+            get
+            {
+                return ResourceManager.GetString("Resume", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to seconds.
+        /// </summary>
+        public static string Seconds
+        {
+            get
+            {
+                return ResourceManager.GetString("Seconds", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Start.
+        /// </summary>
+        public static string Start
+        {
+            get
+            {
+                return ResourceManager.GetString("Start", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Stop.
+        /// </summary>
+        public static string Stop
+        {
+            get
+            {
+                return ResourceManager.GetString("Stop", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Timer.
+        /// </summary>
+        public static string Timer
+        {
+            get
+            {
+                return ResourceManager.GetString("Timer", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Time Setting: .
+        /// </summary>
+        public static string TimeSetting
+        {
+            get
+            {
+                return ResourceManager.GetString("TimeSetting", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Time's up! {0} minutes {1} seconds have passed!.
+        /// </summary>
+        public static string TimeUpMessage
+        {
+            get
+            {
+                return ResourceManager.GetString("TimeUpMessage", resourceCulture);
+            }
+        }
+    }
+}

--- a/wpf/Properties/Resources.ja-JP.resx
+++ b/wpf/Properties/Resources.ja-JP.resx
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <!-- Application Title -->
+  <data name="AppTitle" xml:space="preserve">
+    <value>残り時間メーター</value>
+  </data>
+  <!-- Main Window Labels -->
+  <data name="TimeSetting" xml:space="preserve">
+    <value>時間設定: </value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+    <value>分</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="DisplayMonitor" xml:space="preserve">
+    <value>表示ディスプレー: </value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>配置位置: </value>
+  </data>
+  <data name="PositionRight" xml:space="preserve">
+    <value>右端</value>
+  </data>
+  <data name="PositionLeft" xml:space="preserve">
+    <value>左端</value>
+  </data>
+  <data name="PositionTop" xml:space="preserve">
+    <value>上端</value>
+  </data>
+  <data name="PositionBottom" xml:space="preserve">
+    <value>下端</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>開始</value>
+  </data>
+  <!-- Display Names -->
+  <data name="DisplayFormatPrimary" xml:space="preserve">
+    <value>ディスプレー {0} (主画面) - {1}x{2}</value>
+  </data>
+  <data name="DisplayFormat" xml:space="preserve">
+    <value>ディスプレー {0} - {1}x{2}</value>
+  </data>
+  <!-- Error Messages -->
+  <data name="Error" xml:space="preserve">
+    <value>エラー</value>
+  </data>
+  <data name="InvalidMinutesValue" xml:space="preserve">
+    <value>分の値が正しくありません。</value>
+  </data>
+  <data name="InvalidSecondsValue" xml:space="preserve">
+    <value>秒の値が正しくありません（0-59）。</value>
+  </data>
+  <data name="PleaseSetTimeCorrectly" xml:space="preserve">
+    <value>時間を正しく設定してください。</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>エラーが発生しました: {0}</value>
+  </data>
+  <!-- Timer Window -->
+  <data name="Pause" xml:space="preserve">
+    <value>一時停止</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>再開</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="Timer" xml:space="preserve">
+    <value>タイマー</value>
+  </data>
+  <data name="TimeUpMessage" xml:space="preserve">
+    <value>時間です！{0}分{1}秒経過しました！</value>
+  </data>
+</root>

--- a/wpf/Properties/Resources.resx
+++ b/wpf/Properties/Resources.resx
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <!-- Application Title -->
+  <data name="AppTitle" xml:space="preserve">
+    <value>Remaining Time Meter</value>
+  </data>
+  <!-- Main Window Labels -->
+  <data name="TimeSetting" xml:space="preserve">
+    <value>Time Setting: </value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+    <value>minutes</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="DisplayMonitor" xml:space="preserve">
+    <value>Display Monitor: </value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>Position: </value>
+  </data>
+  <data name="PositionRight" xml:space="preserve">
+    <value>Right edge</value>
+  </data>
+  <data name="PositionLeft" xml:space="preserve">
+    <value>Left edge</value>
+  </data>
+  <data name="PositionTop" xml:space="preserve">
+    <value>Top edge</value>
+  </data>
+  <data name="PositionBottom" xml:space="preserve">
+    <value>Bottom edge</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <!-- Display Names -->
+  <data name="DisplayFormatPrimary" xml:space="preserve">
+    <value>Display {0} (Primary) - {1}x{2}</value>
+  </data>
+  <data name="DisplayFormat" xml:space="preserve">
+    <value>Display {0} - {1}x{2}</value>
+  </data>
+  <!-- Error Messages -->
+  <data name="Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="InvalidMinutesValue" xml:space="preserve">
+    <value>Invalid minutes value.</value>
+  </data>
+  <data name="InvalidSecondsValue" xml:space="preserve">
+    <value>Invalid seconds value (0-59).</value>
+  </data>
+  <data name="PleaseSetTimeCorrectly" xml:space="preserve">
+    <value>Please set the time correctly.</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>An error occurred: {0}</value>
+  </data>
+  <!-- Timer Window -->
+  <data name="Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Resume</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="Timer" xml:space="preserve">
+    <value>Timer</value>
+  </data>
+  <data name="TimeUpMessage" xml:space="preserve">
+    <value>Time's up! {0} minutes {1} seconds have passed!</value>
+  </data>
+</root>

--- a/wpf/Properties/Resources.zh-CN.resx
+++ b/wpf/Properties/Resources.zh-CN.resx
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <!-- Application Title -->
+  <data name="AppTitle" xml:space="preserve">
+    <value>剩余时间计时器</value>
+  </data>
+  <!-- Main Window Labels -->
+  <data name="TimeSetting" xml:space="preserve">
+    <value>时间设置: </value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+    <value>分钟</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="DisplayMonitor" xml:space="preserve">
+    <value>显示器: </value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>位置: </value>
+  </data>
+  <data name="PositionRight" xml:space="preserve">
+    <value>右边</value>
+  </data>
+  <data name="PositionLeft" xml:space="preserve">
+    <value>左边</value>
+  </data>
+  <data name="PositionTop" xml:space="preserve">
+    <value>顶部</value>
+  </data>
+  <data name="PositionBottom" xml:space="preserve">
+    <value>底部</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>开始</value>
+  </data>
+  <!-- Display Names -->
+  <data name="DisplayFormatPrimary" xml:space="preserve">
+    <value>显示器 {0} (主屏) - {1}x{2}</value>
+  </data>
+  <data name="DisplayFormat" xml:space="preserve">
+    <value>显示器 {0} - {1}x{2}</value>
+  </data>
+  <!-- Error Messages -->
+  <data name="Error" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="InvalidMinutesValue" xml:space="preserve">
+    <value>分钟值无效。</value>
+  </data>
+  <data name="InvalidSecondsValue" xml:space="preserve">
+    <value>秒值无效（0-59）。</value>
+  </data>
+  <data name="PleaseSetTimeCorrectly" xml:space="preserve">
+    <value>请正确设置时间。</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>发生错误: {0}</value>
+  </data>
+  <!-- Timer Window -->
+  <data name="Pause" xml:space="preserve">
+    <value>暂停</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>继续</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="Timer" xml:space="preserve">
+    <value>计时器</value>
+  </data>
+  <data name="TimeUpMessage" xml:space="preserve">
+    <value>时间到！已过 {0} 分钟 {1} 秒！</value>
+  </data>
+</root>

--- a/wpf/Properties/Resources.zh-TW.resx
+++ b/wpf/Properties/Resources.zh-TW.resx
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <!-- Application Title -->
+  <data name="AppTitle" xml:space="preserve">
+    <value>剩餘時間計時器</value>
+  </data>
+  <!-- Main Window Labels -->
+  <data name="TimeSetting" xml:space="preserve">
+    <value>時間設定: </value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+    <value>分鐘</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="DisplayMonitor" xml:space="preserve">
+    <value>顯示器: </value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>位置: </value>
+  </data>
+  <data name="PositionRight" xml:space="preserve">
+    <value>右邊</value>
+  </data>
+  <data name="PositionLeft" xml:space="preserve">
+    <value>左邊</value>
+  </data>
+  <data name="PositionTop" xml:space="preserve">
+    <value>頂部</value>
+  </data>
+  <data name="PositionBottom" xml:space="preserve">
+    <value>底部</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>開始</value>
+  </data>
+  <!-- Display Names -->
+  <data name="DisplayFormatPrimary" xml:space="preserve">
+    <value>顯示器 {0} (主螢幕) - {1}x{2}</value>
+  </data>
+  <data name="DisplayFormat" xml:space="preserve">
+    <value>顯示器 {0} - {1}x{2}</value>
+  </data>
+  <!-- Error Messages -->
+  <data name="Error" xml:space="preserve">
+    <value>錯誤</value>
+  </data>
+  <data name="InvalidMinutesValue" xml:space="preserve">
+    <value>分鐘值無效。</value>
+  </data>
+  <data name="InvalidSecondsValue" xml:space="preserve">
+    <value>秒值無效（0-59）。</value>
+  </data>
+  <data name="PleaseSetTimeCorrectly" xml:space="preserve">
+    <value>請正確設定時間。</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>發生錯誤: {0}</value>
+  </data>
+  <!-- Timer Window -->
+  <data name="Pause" xml:space="preserve">
+    <value>暫停</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>繼續</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="Timer" xml:space="preserve">
+    <value>計時器</value>
+  </data>
+  <data name="TimeUpMessage" xml:space="preserve">
+    <value>時間到！已過 {0} 分鐘 {1} 秒！</value>
+  </data>
+</root>

--- a/wpf/RemainingTimeMeter.csproj
+++ b/wpf/RemainingTimeMeter.csproj
@@ -46,6 +46,18 @@
     </ItemGroup>
 
     <ItemGroup>
+        <EmbeddedResource Update="Properties\Resources.resx">
+            <Generator>PublicResXFileCodeGenerator</Generator>
+            <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <Compile Update="Properties\Resources.Designer.cs">
+            <AutoGen>True</AutoGen>
+            <DesignTime>True</DesignTime>
+            <DependentUpon>Resources.resx</DependentUpon>
+        </Compile>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/wpf/TimerWindow.xaml
+++ b/wpf/TimerWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="RemainingTimeMeter.TimerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:properties="clr-namespace:RemainingTimeMeter.Properties"
         Title="Timer" 
         WindowStyle="None" 
         AllowsTransparency="True" 
@@ -48,14 +49,14 @@
 
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <Button x:Name="PauseResumeButton" 
-                            Content="一時停止" 
+                            Content="{Binding Source={x:Static properties:Resources.Pause}}" 
                             Width="80" 
                             Height="30" 
                             Margin="0,0,5,0"
                             Click="PauseResumeButton_Click"/>
 
                     <Button x:Name="StopButton" 
-                            Content="停止" 
+                            Content="{Binding Source={x:Static properties:Resources.Stop}}" 
                             Width="60" 
                             Height="30" 
                             Margin="5,0,0,0"

--- a/wpf/TimerWindow.xaml.cs
+++ b/wpf/TimerWindow.xaml.cs
@@ -106,10 +106,10 @@ namespace RemainingTimeMeter
         {
             return position switch
             {
-                "右端" => TimerPosition.Right,
-                "左端" => TimerPosition.Left,
-                "上端" => TimerPosition.Top,
-                "下端" => TimerPosition.Bottom,
+                var p when p == Properties.Resources.PositionRight => TimerPosition.Right,
+                var p when p == Properties.Resources.PositionLeft => TimerPosition.Left,
+                var p when p == Properties.Resources.PositionTop => TimerPosition.Top,
+                var p when p == Properties.Resources.PositionBottom => TimerPosition.Bottom,
                 _ => TimerPosition.Right,
             };
         }
@@ -272,17 +272,17 @@ namespace RemainingTimeMeter
             // Calculate elapsed time
             int minutes = this.totalSeconds / 60;
             int seconds = this.totalSeconds % 60;
-            string message = $"時間です！{minutes}分{seconds}秒経過しました！";
+            string message = string.Format(Properties.Resources.TimeUpMessage, minutes, seconds);
 
             try
             {
                 // Use Windows 10/11 system notifications
-                this.ShowWindowsNotification("タイマー", message);
+                this.ShowWindowsNotification(Properties.Resources.Timer, message);
             }
             catch
             {
                 // Show message box as fallback
-                System.Windows.MessageBox.Show(message, "タイマー", MessageBoxButton.OK, MessageBoxImage.Information);
+                System.Windows.MessageBox.Show(message, Properties.Resources.Timer, MessageBoxButton.OK, MessageBoxImage.Information);
             }
 
             this.MainWindowRequested?.Invoke();
@@ -400,7 +400,7 @@ namespace RemainingTimeMeter
             try
             {
                 this.isPaused = !this.isPaused;
-                this.PauseResumeButton.Content = this.isPaused ? "再開" : "一時停止";
+                this.PauseResumeButton.Content = this.isPaused ? Properties.Resources.Resume : Properties.Resources.Pause;
                 this.UpdateBarColor(); // Update color when pause state changes
                 Logger.Info($"PauseResumeButton_Click completed - new state: isPaused={this.isPaused}");
             }


### PR DESCRIPTION
## Summary
- Added complete internationalization support for 4 languages: English, Japanese, Simplified Chinese, and Traditional Chinese
- All user-facing text is now localized and supports automatic language switching based on system locale
- Implemented proper resource management with strongly-typed access

## Language Support
- **English (default)**: Complete UI localization
- **Japanese (ja-JP)**: Native Japanese UI, error messages, and notifications
- **Simplified Chinese (zh-CN)**: Mainland China localization
- **Traditional Chinese (zh-TW)**: Taiwan localization

## Changes Made
### Resource Files
- `Properties/Resources.resx` - Default English resources
- `Properties/Resources.ja-JP.resx` - Japanese localization
- `Properties/Resources.zh-CN.resx` - Simplified Chinese localization
- `Properties/Resources.zh-TW.resx` - Traditional Chinese localization
- `Properties/Resources.Designer.cs` - Strongly-typed resource access

### UI Localization
- **MainWindow.xaml**: Updated all text elements to use resource bindings
- **TimerWindow.xaml**: Localized control panel buttons and labels
- **MainWindow.xaml.cs**: Error messages and display names use resources
- **TimerWindow.xaml.cs**: Notifications, position parsing, and button text use resources

### Technical Implementation
- Added proper namespace declarations for resource access in XAML
- Updated project file to include embedded resources with code generation
- Used `Properties.Resources` pattern for consistent resource access
- Dynamic button text updates based on timer state (Pause/Resume)

## Localized Elements
- Application title and window captions
- Time setting labels (minutes, seconds)
- Position options (Right, Left, Top, Bottom)
- Display monitor selection
- Error messages (invalid input, time validation)
- Timer notifications and alerts
- Control panel buttons (Start, Pause, Resume, Stop)

## Test Plan
- [x] Build succeeds without errors
- [x] Application runs with default English localization
- [ ] Test Japanese locale display
- [ ] Test Chinese locale display
- [ ] Verify error messages appear in correct language
- [ ] Test timer notifications in different languages

🤖 Generated with [Claude Code](https://claude.ai/code)