### PR TITLE
Fix position selection bug - timer now respects selected position

### DIFF
--- a/wpf/TimerWindow.xaml.cs
+++ b/wpf/TimerWindow.xaml.cs
@@ -127,6 +127,13 @@ namespace RemainingTimeMeter
         {
             return position switch
             {
+                // Handle simple enum names (from Tag values)
+                "Right" => TimerPosition.Right,
+                "Left" => TimerPosition.Left,
+                "Top" => TimerPosition.Top,
+                "Bottom" => TimerPosition.Bottom,
+
+                // Handle localized resource strings (for backward compatibility)
                 var p when p == Properties.Resources.PositionRight => TimerPosition.Right,
                 var p when p == Properties.Resources.PositionLeft => TimerPosition.Left,
                 var p when p == Properties.Resources.PositionTop => TimerPosition.Top,


### PR DESCRIPTION
## Bug Description
The position selection labels in the setup UI appeared to work (visual feedback was correct), but the timer progress bar **always appeared on the right side** of the display regardless of which position was selected.

## Root Cause Analysis
The issue was in the `ParsePosition` method in `TimerWindow.xaml.cs`:

1. **Position labels send simple names**: Tag values are "Right", "Left", "Top", "Bottom"
2. **ParsePosition expected localized strings**: Method only handled resource strings like "Right edge", "Left edge"
3. **No match found**: Simple names didn't match localized strings, so it defaulted to `TimerPosition.Right`

## Example of the Problem
```csharp
// What position labels send:
selectedPosition = "Left"  // From Tag="Left"

// What ParsePosition expected:
Properties.Resources.PositionLeft = "Left edge"

// Result: No match, defaults to TimerPosition.Right
```

## Solution
Updated `ParsePosition` method to handle **both** formats:

```csharp
private TimerPosition ParsePosition(string position)
{
    return position switch
    {
        // Handle simple enum names (from Tag values) - NEW
        "Right" => TimerPosition.Right,
        "Left" => TimerPosition.Left,
        "Top" => TimerPosition.Top,
        "Bottom" => TimerPosition.Bottom,
        
        // Handle localized resource strings (backward compatibility)
        var p when p == Properties.Resources.PositionRight => TimerPosition.Right,
        var p when p == Properties.Resources.PositionLeft => TimerPosition.Left,
        var p when p == Properties.Resources.PositionTop => TimerPosition.Top,
        var p when p == Properties.Resources.PositionBottom => TimerPosition.Bottom,
        
        _ => TimerPosition.Right,
    };
}
```

## Benefits
- ✅ **Position selection now works**: Timer appears on selected side/edge
- ✅ **Backward compatibility**: Still handles old localized string format
- ✅ **Clean implementation**: Simple string matching for Tag values
- ✅ **Internationalization safe**: Maintains support for all localized strings

## Testing
After this fix:
- Select "左端" (Left) → Timer appears on **left edge** of display
- Select "上端" (Top) → Timer appears on **top edge** of display  
- Select "下端" (Bottom) → Timer appears on **bottom edge** of display
- Select "右端" (Right) → Timer appears on **right edge** of display

## Files Changed
- `TimerWindow.xaml.cs`: Updated `ParsePosition` method to handle both string formats

This fixes the core functionality where position selection was broken, ensuring users can actually control where their timer appears during presentations.

🤖 Generated with [Claude Code](https://claude.ai/code)