### PR TITLE
Fix English UI text truncation issues

### DIFF
--- a/wpf/App.xaml
+++ b/wpf/App.xaml
@@ -46,9 +46,9 @@
         <System:Double x:Key="TitleFontSize" xmlns:System="clr-namespace:System;assembly=mscorlib">24</System:Double>
         
         <!-- Common Dimensions -->
-        <System:Double x:Key="ButtonWidth" xmlns:System="clr-namespace:System;assembly=mscorlib">60</System:Double>
+        <System:Double x:Key="ButtonWidth" xmlns:System="clr-namespace:System;assembly=mscorlib">75</System:Double>
         <System:Double x:Key="ButtonHeight" xmlns:System="clr-namespace:System;assembly=mscorlib">30</System:Double>
-        <System:Double x:Key="QuickButtonWidth" xmlns:System="clr-namespace:System;assembly=mscorlib">50</System:Double>
+        <System:Double x:Key="QuickButtonWidth" xmlns:System="clr-namespace:System;assembly=mscorlib">55</System:Double>
         <System:Double x:Key="LargeButtonWidth" xmlns:System="clr-namespace:System;assembly=mscorlib">100</System:Double>
         <System:Double x:Key="LargeButtonHeight" xmlns:System="clr-namespace:System;assembly=mscorlib">40</System:Double>
         <CornerRadius x:Key="SmallCornerRadius">2</CornerRadius>
@@ -151,7 +151,7 @@
         
         <!-- ComboBox Style -->
         <Style x:Key="DisplayComboBoxStyle" TargetType="ComboBox">
-            <Setter Property="Width" Value="200"/>
+            <Setter Property="MinWidth" Value="200"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
         

--- a/wpf/MainWindow.xaml
+++ b/wpf/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:properties="clr-namespace:RemainingTimeMeter.Properties"
-        Title="{Binding Source={x:Static properties:Resources.AppTitle}}" Height="350" Width="400"
+        Title="{Binding Source={x:Static properties:Resources.AppTitle}}" Height="350" Width="450"
         WindowStartupLocation="CenterScreen"
         Icon="tv_timekeeper_trimmed.ico">
     <Grid>
@@ -31,7 +31,7 @@
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
                 <TextBlock Text="{Binding Source={x:Static properties:Resources.DisplayMonitor}}" Style="{StaticResource LabelTextStyle}"/>
-                <ComboBox x:Name="DisplayComboBox" Style="{StaticResource DisplayComboBoxStyle}" SelectedIndex="0"/>
+                <ComboBox x:Name="DisplayComboBox" Style="{StaticResource DisplayComboBoxStyle}" SelectedIndex="0" MaxWidth="250"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,10">


### PR DESCRIPTION
## Summary
Fix text truncation issues when using English language in the application interface.

## Issues Fixed

### Text Truncation Problems
- **Control buttons** (Pause/Resume/Stop) were too narrow for English text
- **Quick time buttons** (1min, 5min, etc.) couldn't display full labels
- **Display ComboBox** was limited to 200px for potentially long display names
- **"Position:" label** was cut off on the left side of the main window

## Changes Made

### Button Width Adjustments
- **Control button width**: 60px → 75px (accommodates "Resume" text)
- **Quick time button width**: 50px → 55px (fits "1min", "5min" labels)

### Layout Improvements  
- **Display ComboBox**: Changed from fixed `Width="200"` to `MinWidth="200"` with `MaxWidth="250"`
- **Main window width**: 400px → 450px (prevents "Position:" label truncation)

### Multi-language Compatibility
- Ensures Traditional Chinese "分鐘" fits in 55px quick time buttons
- Maintains compatibility with Simplified Chinese "分钟" and Japanese "分"
- English "min" labels display comfortably

## Before/After
**Before**: Text was partially hidden, especially "Position:" label and button text
**After**: All English text displays fully without truncation

## Test Plan
- [x] Test English interface (`--lang en-US`)
- [x] Verify all button text is visible
- [x] Confirm "Position:" label displays fully
- [x] Check display ComboBox accommodates long names
- [x] Test other languages still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)